### PR TITLE
Add Docker deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml* poetry.lock* ./
+RUN pip install --no-cache-dir poetry \
+    && poetry install --no-interaction --no-ansi --no-root
+
+COPY . /app/
+
+RUN poetry run python manage.py collectstatic --noinput 2>/dev/null || true
+
+CMD ["poetry", "run", "gunicorn", "djproject.wsgi:application", "-b", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
 # celery_tasklog
-A system for logging task stdout/stderr to database and streaming them to client. 
+
+`celery_tasklog` provides a Django application that records stdout/stderr from Celery tasks in the database so logs can be streamed to the browser. The package is packaged with Poetry and can be used in any project.
+
+## Features
+
+* Database model `TaskLogLine` to persist task output.
+* Middleware and admin integration.
+* Utilities such as cleanup commands and diagnostic views.
+
+Configuration options are exposed through environment variables as described in the [specification](docs/CeleryTaskLogSpec.md):
+
+- `CELERY_TASKLOG_ENABLED` – enable or disable logging (default `True`).
+- `CELERY_TASKLOG_MAX_LINES` – maximum log lines stored per task (default `1000`).
+- `CELERY_TASKLOG_RETENTION_DAYS` – log retention in days (default `30`).
+
+## Usage in your project
+
+1. Install the package:
+   ```bash
+   pip install celery_tasklog
+   ```
+2. Add `celery_tasklog` to `INSTALLED_APPS` and include `CeleryTaskLogMiddleware` in your middleware list.
+3. Run database migrations:
+   ```bash
+   python manage.py migrate
+   ```
+4. Start the Celery worker alongside your Django server. Example commands can be found in the [verification steps](docs/CeleryTaskLogSpec.md).
+
+## Docker deployment
+
+A Dockerfile is provided following the structure from the specification:
+
+```Dockerfile
+# Use the official Python image from the Docker Hub
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+```
+[...]
+
+The docker-compose file builds the image, runs the web application, Celery worker, beat scheduler, Flower dashboard and a PostgreSQL database:
+
+```yaml
+version: '3.8'
+services:
+  web:
+    build: .
+    command: poetry run gunicorn djproject.wsgi:application -b 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+      - worker
+  worker:
+    build: .
+    command: poetry run celery -A djproject worker -l info
+```
+(see `docker-compose.yml` for the full configuration).
+
+Environment variables are loaded from `.env`, keeping the project [12‑factor](https://12factor.net/) compliant.
+
+## Running locally
+
+1. Create a `.env` file with at least the PostgreSQL credentials used in `docker-compose.yml`.
+2. Build and start the stack:
+   ```bash
+   docker compose up --build
+   ```
+3. Access Flower at [http://localhost:5555](http://localhost:5555) and the Django site at [http://localhost:8000](http://localhost:8000).
+
+For more details see the full [CeleryTaskLogSpec](docs/CeleryTaskLogSpec.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    command: poetry run gunicorn djproject.wsgi:application -b 0.0.0.0:8000
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+      - worker
+  worker:
+    build: .
+    command: poetry run celery -A djproject worker -l info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+  beat:
+    build: .
+    command: poetry run celery -A djproject beat -l info
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+  flower:
+    build: .
+    command: poetry run celery -A djproject flower
+    ports:
+      - "5555:5555"
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+  redis:
+    image: redis:alpine
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-celery_tasklog}
+      POSTGRES_USER: ${POSTGRES_USER:-celery_tasklog}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-celery_tasklog}
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- add Dockerfile for deploying Django project under /app
- add docker-compose with Celery worker/beat, Flower, Redis and PostgreSQL
- document how to integrate the package and run with Docker

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68417727aa048330a8ef462b8caf47c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Dockerfile and docker-compose.yml for easy containerization and orchestration of the application, including web, worker, beat, monitoring, Redis, and Postgres services.
- **Documentation**
  - Expanded README with detailed setup, configuration, usage instructions, and Docker deployment guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->