### PR TITLE
Implement celery_tasklog project

### DIFF
--- a/celery_tasklog/pyproject.toml
+++ b/celery_tasklog/pyproject.toml
@@ -1,0 +1,17 @@
+[tool.poetry]
+name = "celery_tasklog"
+version = "0.1.0"
+description = "Celery Task Log - Real-time task monitoring for Django/Celery"
+authors = ["Your Name <you@example.com>"]
+license = "MIT"
+packages = [{include = "celery_tasklog", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+Django = "^3.2"
+celery = "^5.2"
+django-celery-results = "^2.5"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/celery_tasklog/src/celery_tasklog/__init__.py
+++ b/celery_tasklog/src/celery_tasklog/__init__.py
@@ -1,0 +1,3 @@
+from .apps import CeleryTaskLogConfig
+
+__all__ = ["CeleryTaskLogConfig"]

--- a/celery_tasklog/src/celery_tasklog/admin.py
+++ b/celery_tasklog/src/celery_tasklog/admin.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from .models import TaskLogLine
+
+
+@admin.register(TaskLogLine)
+class TaskLogLineAdmin(admin.ModelAdmin):
+    list_display = ('task_id', 'timestamp', 'stream', 'message')
+    list_filter = ('stream',)
+    search_fields = ('task_id', 'message')

--- a/celery_tasklog/src/celery_tasklog/apps.py
+++ b/celery_tasklog/src/celery_tasklog/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CeleryTaskLogConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "celery_tasklog"

--- a/celery_tasklog/src/celery_tasklog/middleware.py
+++ b/celery_tasklog/src/celery_tasklog/middleware.py
@@ -1,0 +1,9 @@
+class CeleryTaskLogMiddleware:
+    """Middleware placeholder for task logging context."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response

--- a/celery_tasklog/src/celery_tasklog/migrations/0001_initial.py
+++ b/celery_tasklog/src/celery_tasklog/migrations/0001_initial.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name='TaskLogLine',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('task_id', models.CharField(db_index=True, max_length=255)),
+                ('timestamp', models.DateTimeField(auto_now_add=True)),
+                ('stream', models.CharField(choices=[('stdout', 'stdout'), ('stderr', 'stderr')], max_length=10)),
+                ('message', models.TextField()),
+            ],
+            options={'ordering': ['id']},
+        ),
+    ]

--- a/celery_tasklog/src/celery_tasklog/models.py
+++ b/celery_tasklog/src/celery_tasklog/models.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class TaskLogLine(models.Model):
+    task_id = models.CharField(max_length=255, db_index=True)
+    timestamp = models.DateTimeField(auto_now_add=True)
+    stream = models.CharField(max_length=10, choices=[("stdout", "stdout"), ("stderr", "stderr")])
+    message = models.TextField()
+
+    class Meta:
+        ordering = ["id"]
+
+    def __str__(self):
+        return f"{self.timestamp} [{self.stream}] {self.message}"

--- a/celery_tasklog/src/celery_tasklog/tasks.py
+++ b/celery_tasklog/src/celery_tasklog/tasks.py
@@ -1,0 +1,121 @@
+import random
+import time
+from contextlib import contextmanager
+from datetime import datetime
+import pytz
+import sys
+
+from celery import Task, shared_task
+from celery.utils.log import get_task_logger
+
+from .models import TaskLogLine
+
+logger = get_task_logger(__name__)
+
+
+class DBLogWriter:
+    def __init__(self, task_id: str, stream: str):
+        self.task_id = task_id
+        self.stream = stream
+        self.buffer = ""
+
+    def write(self, msg: str):
+        self.buffer += msg
+        while "\n" in self.buffer:
+            line, self.buffer = self.buffer.split("\n", 1)
+            if line:
+                TaskLogLine.objects.create(task_id=self.task_id, stream=self.stream, message=line)
+
+    def flush(self):
+        if self.buffer:
+            TaskLogLine.objects.create(task_id=self.task_id, stream=self.stream, message=self.buffer)
+            self.buffer = ""
+
+
+@contextmanager
+def capture_output(task_id: str):
+    stdout_writer = DBLogWriter(task_id, "stdout")
+    stderr_writer = DBLogWriter(task_id, "stderr")
+    old_stdout = sys.stdout
+    old_stderr = sys.stderr
+    sys.stdout = stdout_writer
+    sys.stderr = stderr_writer
+    try:
+        yield
+    finally:
+        stdout_writer.flush()
+        stderr_writer.flush()
+        sys.stdout = old_stdout
+        sys.stderr = old_stderr
+
+
+class TerminalLoggingTask(Task):
+    def __call__(self, *args, **kwargs):
+        task_id = self.request.id
+        with capture_output(task_id):
+            return self.run(*args, **kwargs)
+
+
+@shared_task(bind=True, base=TerminalLoggingTask, name='celery_tasklog.tasks.timed_print_task')
+def timed_print_task(self):
+    try:
+        task_id = self.request.id
+        TaskLogLine.objects.create(task_id=task_id, stream='stdout', message=f"Task {task_id} started manually")
+        logger.info(f"Starting timed_print_task with ID: {task_id}")
+
+        self.update_state(state='STARTED', meta={'progress': 0})
+
+        duration = random.randint(5, 10)
+        end_time = time.time() + duration
+
+        TaskLogLine.objects.create(
+            task_id=task_id,
+            stream='stdout',
+            message=f"Task will run for approximately {duration} seconds"
+        )
+
+        iteration = 0
+        total_iterations = duration * 2
+
+        while time.time() < end_time:
+            iteration += 1
+            timestamp = datetime.now(tz=pytz.UTC).isoformat()
+
+            progress = min(int((iteration / total_iterations) * 100), 99)
+            self.update_state(state='PROGRESS', meta={'progress': progress})
+
+            TaskLogLine.objects.create(
+                task_id=task_id,
+                stream='stdout',
+                message=f"Iteration {iteration}: {timestamp} (Progress: {progress}%)"
+            )
+
+            logger.info(f"Iteration {iteration}: {timestamp} (Progress: {progress}%)")
+
+            time.sleep(random.uniform(0.5, 1))
+
+        TaskLogLine.objects.create(
+            task_id=task_id,
+            stream='stdout',
+            message=f"Task {task_id} completed successfully after {iteration} iterations"
+        )
+        logger.info(f"Task {task_id} completed successfully after {iteration} iterations")
+
+        return {
+            "status": "done",
+            "iterations": iteration,
+            "duration": duration
+        }
+    except Exception as e:
+        error_msg = f"Error in timed_print_task: {str(e)}"
+        logger.error(error_msg)
+        try:
+            task_id = getattr(self.request, 'id', 'unknown')
+            TaskLogLine.objects.create(
+                task_id=task_id,
+                stream='stderr',
+                message=error_msg
+            )
+        except Exception as inner_e:
+            logger.error(f"Failed to log error to database: {str(inner_e)}")
+        raise

--- a/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/diagnostic.html
+++ b/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/diagnostic.html
@@ -1,0 +1,2 @@
+<h1>Celery TaskLog Diagnostic</h1>
+<p>This page confirms the task logging views are working.</p>

--- a/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/launch_task.html
+++ b/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/launch_task.html
@@ -1,0 +1,5 @@
+<h1>Launch Test Task</h1>
+<form method="post">
+  {% csrf_token %}
+  <button type="submit">Start Task</button>
+</form>

--- a/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/task_view.html
+++ b/celery_tasklog/src/celery_tasklog/templates/celery_tasklog/task_view.html
@@ -1,0 +1,5 @@
+<h1>Task {{ task_id }} Log</h1>
+<pre>
+{% for line in logs %}{{ line.timestamp }} [{{ line.stream }}] {{ line.message }}
+{% endfor %}
+</pre>

--- a/celery_tasklog/src/celery_tasklog/urls.py
+++ b/celery_tasklog/src/celery_tasklog/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('task/<str:task_id>/', views.task_log_view, name='task_log'),
+    path('diagnostic/', views.task_diagnostic, name='task_diagnostic'),
+]

--- a/celery_tasklog/src/celery_tasklog/views.py
+++ b/celery_tasklog/src/celery_tasklog/views.py
@@ -1,0 +1,11 @@
+from django.shortcuts import render
+from .models import TaskLogLine
+
+
+def task_log_view(request, task_id):
+    logs = TaskLogLine.objects.filter(task_id=task_id).order_by('timestamp')
+    return render(request, 'celery_tasklog/task_view.html', {'logs': logs, 'task_id': task_id})
+
+
+def task_diagnostic(request):
+    return render(request, 'celery_tasklog/diagnostic.html')

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,0 +1,1 @@
+# Demo app

--- a/demo/tasks.py
+++ b/demo/tasks.py
@@ -1,0 +1,9 @@
+from celery import shared_task
+import time
+
+@shared_task(bind=True)
+def long_running_task(self, seconds: int):
+    for i in range(seconds):
+        print(f"Processing step {i+1}/{seconds}")
+        time.sleep(1)
+    return f"Completed {seconds} second task"

--- a/demo/templates/demo/demo_complete.html
+++ b/demo/templates/demo/demo_complete.html
@@ -1,0 +1,2 @@
+<p>Task launched for {{ seconds }} seconds.</p>
+<p>Check <a href="/tasklog/diagnostic/">task diagnostic</a>.</p>

--- a/demo/templates/demo/demo_form.html
+++ b/demo/templates/demo/demo_form.html
@@ -1,0 +1,6 @@
+<form method="post">
+  {% csrf_token %}
+  <label>Seconds:</label>
+  <input type="number" name="seconds" value="5"/>
+  <button type="submit">Run Task</button>
+</form>

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.demo_view, name='demo'),
+]

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,0 +1,10 @@
+from django.shortcuts import render
+from .tasks import long_running_task
+
+
+def demo_view(request):
+    if request.method == 'POST':
+        seconds = int(request.POST.get('seconds', 5))
+        long_running_task.delay(seconds)
+        return render(request, 'demo/demo_complete.html', {'seconds': seconds})
+    return render(request, 'demo/demo_form.html')

--- a/djproject/__init__.py
+++ b/djproject/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/djproject/asgi.py
+++ b/djproject/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'djproject.settings')
+application = get_asgi_application()

--- a/djproject/celery.py
+++ b/djproject/celery.py
@@ -1,0 +1,13 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'djproject.settings')
+
+app = Celery('djproject')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
+
+
+@app.task
+def debug_task(self):
+    print(f'Request: {self.request!r}')

--- a/djproject/settings.py
+++ b/djproject/settings.py
@@ -1,0 +1,75 @@
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = 'django-insecure-placeholder'
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django_celery_results',
+    'celery_tasklog',
+    'demo',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'celery_tasklog.middleware.CeleryTaskLogMiddleware',
+]
+
+ROOT_URLCONF = 'djproject.urls'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [BASE_DIR / 'templates'],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = 'djproject.wsgi.application'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = '/static/'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+CELERY_BROKER_URL = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+CELERY_RESULT_BACKEND = 'django-db'
+
+CELERY_TASKLOG_ENABLED = True
+CELERY_TASKLOG_MAX_LINES = 1000
+CELERY_TASKLOG_RETENTION_DAYS = 30

--- a/djproject/urls.py
+++ b/djproject/urls.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('', include('demo.urls')),
+    path('tasklog/', include('celery_tasklog.urls')),
+]

--- a/djproject/wsgi.py
+++ b/djproject/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'djproject.settings')
+application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == '__main__':
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'djproject.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.poetry]
+name = "celery-tasklog-project"
+version = "0.1.0"
+description = "Demo project for celery_tasklog"
+authors = ["Example <example@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+Django = "^3.2"
+celery = "^5.2"
+redis = "^4.0"
+django-celery-results = "^2.5"
+celery-tasklog = {path = "celery_tasklog", develop = true}
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- create Poetry config for project and package
- implement Django project with Celery integration
- add demo app with a simple task
- implement `celery_tasklog` package containing models, admin, tasks, middleware, views, URLs and templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417c65da4483309e934c4c4b518f0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Django project with Celery integration for asynchronous task processing and logging.
  - Added a task logging app that captures and displays real-time Celery task output in the database and via the web interface.
  - Provided admin customization for viewing task logs and filtering/searching log entries.
  - Implemented demo tasks and simple web forms to launch and monitor long-running tasks.
  - Included diagnostic and task log views for monitoring task execution and output.
- **Chores**
  - Added configuration files for project setup and dependency management using Poetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->