### PR TITLE
Move demo task trigger and update integration docs

### DIFF
--- a/celery_tasklog/src/celery_tasklog/urls.py
+++ b/celery_tasklog/src/celery_tasklog/urls.py
@@ -7,7 +7,6 @@ app_name = 'celery_tasklog'
 api_urlpatterns = [
     path('tasks/', api_views.TaskListView.as_view(), name='task_list'),
     path('tasks/<str:task_id>/', api_views.TaskDetailView.as_view(), name='task_detail'),
-    path('trigger-demo/', api_views.trigger_demo_task, name='trigger_demo_task'),
 ]
 
 # SSE URLs for real-time log streaming (reusable by any app)

--- a/demo/templates/demo/demo_home.html
+++ b/demo/templates/demo/demo_home.html
@@ -142,7 +142,7 @@
             submitBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Starting...';
             
             try {
-                const response = await fetch('/tasklog/api/trigger-demo/', {
+                const response = await fetch('/demo/api/trigger-demo/', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     # Demo pages
     path('', views.demo_home, name='demo_home'),
     path('task/<str:task_id>/', views.demo_task_detail, name='demo_task_detail'),
+    path('api/trigger-demo/', views.trigger_demo_task, name='trigger_demo_task'),
 ]

--- a/demo/views.py
+++ b/demo/views.py
@@ -1,11 +1,58 @@
 from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework import status
+from rest_framework.response import Response
 
 
 def demo_home(request):
-    """Demo home page with task trigger form and task list"""
-    return render(request, 'demo/demo_home.html')
+    """Demo home page with task trigger form and task list."""
+    return render(request, "demo/demo_home.html")
 
 
 def demo_task_detail(request, task_id):
-    """Demo task detail page with real-time logs"""
-    return render(request, 'demo/demo_task_detail.html', {'task_id': task_id})
+    """Demo task detail page with real-time logs."""
+    return render(request, "demo/demo_task_detail.html", {"task_id": task_id})
+
+
+@api_view(["POST"])
+def trigger_demo_task(request):
+    """Endpoint to start one of the demo tasks."""
+    try:
+        from demo.tasks import demo_long_task, demo_failing_task, demo_quick_task
+    except ImportError:
+        return Response(
+            {
+                "error": "Demo tasks not available. Make sure the demo app is installed and configured."
+            },
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    task_type = request.data.get("task_type", "long")
+    duration = request.data.get("duration", 60)
+
+    try:
+        duration = int(duration)
+        if duration < 1 or duration > 300:
+            duration = 60
+    except (ValueError, TypeError):
+        duration = 60
+
+    if task_type == "failing":
+        result = demo_failing_task.delay()
+        message = "Demo failing task started"
+    elif task_type == "quick":
+        result = demo_quick_task.delay()
+        message = "Demo quick task started"
+    else:
+        result = demo_long_task.delay(duration)
+        message = f"Demo long task started with duration {duration} seconds"
+
+    return Response(
+        {
+            "task_id": result.id,
+            "task_type": task_type,
+            "duration": duration if task_type == "long" else None,
+            "message": message,
+        }
+    )
+


### PR DESCRIPTION
## Summary
- relocate `trigger_demo_task` from reusable package to the demo app
- hook the new view up in `demo/urls.py`
- update demo home page to call the new API endpoint
- remove demo endpoint from `celery_tasklog.urls`
- expand README with a detailed integration guide and example JS code

## Testing
- `flake8`
- `pytest -q` (fails: fixture 'live_server' not found)

------
https://chatgpt.com/codex/tasks/task_e_6841f18678908330830b4da263f1433c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive "Integration Guide" to the README, including step-by-step setup instructions and real-time log consumption examples.

- **Bug Fixes**
  - Updated the demo home page to use the correct API endpoint for triggering demo tasks.

- **New Features**
  - Introduced a new API endpoint in the demo app for triggering demo tasks asynchronously.

- **Refactor**
  - Moved the demo task trigger API endpoint from the main app to the demo app for better separation of concerns.
  - Updated URL configurations to reflect the new location of the demo task trigger endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->