### PR TITLE
Add CI and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt flake8 pytest
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest -vv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+      - name: Publish package
+        run: |
+          cd celery_tasklog
+          poetry publish --build -n
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- add basic CI GitHub Action for linting and tests
- add publish workflow to upload package to PyPI on tag push

## Testing
- `flake8`
- `pytest -q` *(fails: OperationalError: no such table: celery_tasklog_tasklogline)*

------
https://chatgpt.com/codex/tasks/task_e_684276727ef483309fa6d721a4d34e04

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated workflows for continuous integration and publishing. Code is now automatically linted, tested, and published to PyPI when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->